### PR TITLE
Clarification of "methods" learning outcomes in JS Fundamentals 2 

### DIFF
--- a/foundations/javascript_basics/fundamentals-2.md
+++ b/foundations/javascript_basics/fundamentals-2.md
@@ -7,7 +7,7 @@ By the end of this lesson, you should be able to:
 * Name the eight data types in JavaScript.
 * Understand the difference between single, double, and backtick quotes.
 * Embed a variable/expression in a string.
-* Define what a method is.
+* Understand what a method is.
 * Name the three logical operators.
 * Understand what the comparison operators are.
 * Understand what conditionals are.
@@ -67,8 +67,7 @@ This section contains questions for you to check your understanding of this less
 * <a class="knowledge-check-link" href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings#concatenating_strings"> Which type of quote lets you embed variables/expressions in a string?</a>
 * <a class="knowledge-check-link" href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings#concatenating_strings">How do you embed variables/expressions in a string?</a>
 * <a class="knowledge-check-link" href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings#escaping_characters_in_a_string">How do you escape characters in a string?</a>
-* <a class="knowledge-check-link" href="https://www.w3schools.com/js/js_string_methods.asp">What are methods?</a>
-* <a class="knowledge-check-link" href="https://www.w3schools.com/js/js_string_methods.asp">What is the difference between slice/substring/substr?</a>
+* <a class="knowledge-check-link" href="https://www.w3schools.com/js/js_string_methods.asp">What is the difference between the slice/substring/substr string methods?</a>
 * <a class="knowledge-check-link" href="http://javascript.info/logical-operators">What are the three logical operators and what do they stand for?</a>
 * <a class="knowledge-check-link" href="https://javascript.info/comparison">What are the comparison operators?</a>
 * <a class="knowledge-check-link" href="https://javascript.info/ifelse#boolean-conversion">What are truthy and falsy values?</a>


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

These changes:
1. Remove a confusing knowledge check which asked the learner to define methods, but linked to a W3 schools string methods.
2. Clarify the learning outcomes of the lesson regarding JS methods
3. Modify the text of the string methods knowledge check to be more explicit

The acceptance criteria for this PR were given as:
* Reword "Define what a method is" to "Understand what a method is." in learning outcomes
* Remove "What are methods?" knowledge check
* Reword "What is the difference between slice/substring/substr?" to "What is the difference between slice/substring/substr string methods?"
* Don't break anything else 

I reworded the suggested "What is the difference..." text slightly to make it more readable. Otherwise, changes are as discussed.

#### 2. Related Issue

Closes #23529
